### PR TITLE
Update CI rules, improve linting

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,11 +9,8 @@ on:
   schedule:
     - cron: "32 19 * * *"
   push:
-    branches: ["main"]
     # Publish semver tags as releases.
     tags: ["v*.*.*"]
-  pull_request:
-    branches: ["main"]
   workflow_dispatch:
   workflow_call:
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,6 +22,7 @@ env:
 
 jobs:
   docker_build:
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,10 +5,6 @@ name: Tests
 
 on:
   workflow_call:
-  push:
-    branches: ["main"]
-  pull_request:
-    branches: ["main"]
 
 jobs:
   test:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,14 +7,10 @@ linters:
   presets:
     - bugs
     - comment
-    - complexity
     - error
-    - format
     - import
     - metalinter
     - module
     - performance
     - sql
-    - style
-    - test
     - unused

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,3 +14,5 @@ linters:
     - performance
     - sql
     - unused
+  disable:
+    - depguard

--- a/main.go
+++ b/main.go
@@ -15,10 +15,9 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/exp/slog"
-
 	"github.com/peterbourgon/ff/v3/ffcli"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"golang.org/x/exp/slog"
 	"tailscale.com/client/tailscale"
 	"tailscale.com/tsnet"
 	"tailscale.com/types/logger"
@@ -88,7 +87,7 @@ type validTailnetSrv struct {
 
 func tailnetSrvFromArgs(args []string) (*validTailnetSrv, *ffcli.Command, error) {
 	s := &TailnetSrv{}
-	var fs = flag.NewFlagSet("tsnsrv", flag.ExitOnError)
+	fs := flag.NewFlagSet("tsnsrv", flag.ExitOnError)
 	fs.StringVar(&s.UpstreamTCPAddr, "upstreamTCPAddr", "", "Proxy to an HTTP service listening on this TCP address")
 	fs.StringVar(&s.UpstreamUnixAddr, "upstreamUnixAddr", "", "Proxy to an HTTP service listening on this UNIX domain socket address")
 	fs.BoolVar(&s.Ephemeral, "ephemeral", false, "Declare this service ephemeral")

--- a/proxy.go
+++ b/proxy.go
@@ -122,7 +122,7 @@ func (s *validTailnetSrv) rewrite(r *httputil.ProxyRequest) {
 	}))
 }
 
-// Clean up and set user/node identity headers:
+// Clean up and set user/node identity headers:.
 func (s *validTailnetSrv) setWhoisHeaders(r *httputil.ProxyRequest) *apitype.WhoIsResponse {
 	// First, clean out any input we received that looks like TS setting headers:
 	for k := range r.Out.Header {

--- a/proxy.go
+++ b/proxy.go
@@ -74,7 +74,7 @@ func (s *validTailnetSrv) modifyResponse(res *http.Response) error {
 	return nil
 }
 
-func (s *validTailnetSrv) errorHandler(rw http.ResponseWriter, r *http.Request, err error) {
+func (s *validTailnetSrv) errorHandler(rw http.ResponseWriter, _ *http.Request, err error) {
 	slog.Warn("proxy error",
 		"error", err,
 	)


### PR DESCRIPTION
This should leave only the linters active that I actually care about (style?) and fix the lints that golangci-lint screams about.