### PR TITLE
nixos: set systemd service's ProtectProc setting to "noaccess"

### DIFF
--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -188,7 +188,7 @@
               ProtectClock = true;
               ProtectControlGroups = true;
               ProtectHome = true;
-              ProtectProc = true;
+              ProtectProc = "noaccess";
               ProtectKernelModules = true;
               ProtectHostname = true;
               ProtectKernelLogs = true;


### PR DESCRIPTION
This is the most restrictive mode, disallowing the service from ptrace-attaching (or even seeing the PIDs) of any other process on the system, even the ones running as its own user.

That's what I'd meant when setting ProtectProc to "true", but that is of course an invalid value: "Failed to parse /proc/ protection mode, ignoring: true"