### PR TITLE
Activate the GHA cache for docker builds

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -68,3 +68,4 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-to: type=gha,mode=max
+          cache-from: type=gha

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -67,3 +67,4 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,13 +22,20 @@ env:
 
 jobs:
   docker_build:
-    #if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     strategy:
       matrix:
         platform:
           - linux/amd64
           - linux/arm64
+        isPR:
+          - ${{github.event_name == 'pull_request'}}
+
+        # Run only the amd64 build in pull reqs:
+        exclude:
+          - { isPR: true }
+        include:
+          - { platform: "linux/amd64" }
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   docker_build:
-    if: github.event_name != 'pull_request'
+    #if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,6 +24,11 @@ jobs:
   docker_build:
     #if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
     permissions:
       contents: read
       packages: write
@@ -58,12 +63,12 @@ jobs:
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
-      - name: Build and push Docker image
+      - name: Build and push Docker image for ${{matrix.platform}}
         id: build-and-push
         uses: docker/build-push-action@v4
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,11 @@ WORKDIR /work
 ENV CGO_ENABLED=0
 
 COPY go.mod go.sum ./
-RUN go mod download && go mod verify
+RUN go mod download && \
+    go mod verify && \
+    echo 'package main\nimport (_ "tailscale.com/tsnet")\nfunc main(){}' > main.go && \
+    go build -v ./ && \
+    rm main.go
 
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ ENV CGO_ENABLED=0
 COPY go.mod go.sum ./
 RUN go mod download && \
     go mod verify && \
-    echo 'package main\nimport (_ "tailscale.com/tsnet")\nfunc main(){}' > main.go && \
-    go build -v ./ && \
+    echo 'package main\nimport (\n_ "tailscale.com/tsnet"\n_ "tailscale.com/client/tailscale"\n)\nfunc main(){}' > main.go && \
+    go build -ldflags="-s -w" -v ./ && \
     rm main.go
 
 COPY . .


### PR DESCRIPTION
Maybe this will speed up the build of dependencies? Caching & splitting the many platforms' builds speeds this up enough that we can probably use it in CI without too onerous a wait time. Yay!