### PR TITLE
Update pinned go version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/antifuchs/tsnsrv
 
-go 1.18
+go 1.20
 
 require (
 	github.com/peterbourgon/ff/v3 v3.4.0


### PR DESCRIPTION
This ought to fix the CI task by using the go version that we actually need.