### PR TITLE
Don't do docker pushes on merge_group builds

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -29,7 +29,7 @@ jobs:
           - linux/amd64
           - linux/arm64
         isPR:
-          - ${{github.event_name == 'pull_request'}}
+          - ${{github.event_name == 'pull_request' || github.event_name == 'merge_group'}}
 
         # Run only the amd64 build in pull reqs:
         exclude:
@@ -53,7 +53,7 @@ jobs:
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
-        if: github.event_name != 'pull_request'
+        if: matrix.isPR == false
         uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
@@ -76,7 +76,7 @@ jobs:
         with:
           context: .
           platforms: ${{ matrix.platform }}
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ matrix.isPR == false }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-to: type=gha,mode=max


### PR DESCRIPTION
* Adjust the condition for the `isPR` matrix key to be true, by checking the github event name: it's true if the event was pull_request or merge_group.

* Adjust all other github.event_name conditions to use the matrix.isPR context key.

This fixes #29.