### PR TITLE
Add a tsnsrvOciImage package and an app that streams that image

### DIFF
--- a/.github/workflows/ci_nix.yml
+++ b/.github/workflows/ci_nix.yml
@@ -17,8 +17,7 @@ jobs:
     uses: "boinkor-net/ci-baseline-nix/.github/workflows/build.yml@main"
     strategy:
       matrix:
-        derivation: [""]
+        derivation: ["", "tsnsrvOciImage"]
     with:
       root: "."
       installable: ${{matrix.derivation}}
-

--- a/flake.nix
+++ b/flake.nix
@@ -27,10 +27,18 @@
           tag = "latest";
           created = builtins.substring 0 8 self.lastModifiedDate;
           contents = [
-            config.packages.tsnsrv
+            (pkgs.buildEnv {
+              name = "image-root";
+              paths = [config.packages.tsnsrv];
+              pathsToLink = ["/bin"];
+            })
             pkgs.dockerTools.caCertificates
           ];
-          config.EntryPoint = ["${config.packages.tsnsrv}/bin/tsnsrv"];
+
+          extraCommands = ''
+            mkdir -p /tmp
+          '';
+          config.EntryPoint = ["/bin/tsnsrv"];
         };
       in {
         overlayAttrs = {


### PR DESCRIPTION
This addresses the first part of #28: Now NixOS users have an easy way to reference a docker image that corresponds to the package we're building.

This also improves the command-line building logic by using _way_ less string interpolation. That'll be useful when we construct the docker container commandline.