### PR TITLE
Correctly fix the nonsensical inability to create /tmp in the docker image

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,7 @@
             pkgs.dockerTools.caCertificates
           ];
 
-          extraCommands = "mkdir -p /tmp";
+          extraCommands = "mkdir -p /tmp; touch /tmp/.ignore";
           config.EntryPoint = ["/bin/tsnsrv"];
         };
       in {

--- a/flake.nix
+++ b/flake.nix
@@ -29,12 +29,11 @@
             (pkgs.buildEnv {
               name = "image-root";
               paths = [config.packages.tsnsrv];
-              pathsToLink = ["/bin"];
+              pathsToLink = ["/bin" "/tmp"];
             })
             pkgs.dockerTools.caCertificates
           ];
 
-          fakeRootCommands = "mkdir -p /tmp; touch /tmp/.ignore; mkdir /data";
           config.EntryPoint = ["/bin/tsnsrv"];
         };
       in {

--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,7 @@
             pkgs.dockerTools.caCertificates
           ];
 
-          extraCommands = "mkdir -p /tmp; touch /tmp/.ignore; mkdir /data";
+          fakeRootCommands = "mkdir -p /tmp; touch /tmp/.ignore; mkdir /data";
           config.EntryPoint = ["/bin/tsnsrv"];
         };
       in {

--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,7 @@
             pkgs.dockerTools.caCertificates
           ];
 
-          extraCommands = "mkdir -p /tmp; touch /tmp/.ignore";
+          extraCommands = "mkdir -p /tmp; touch /tmp/.ignore; mkdir /data";
           config.EntryPoint = ["/bin/tsnsrv"];
         };
       in {


### PR DESCRIPTION
seems that `extraCommands` and `fakeRootCommands` don't; the easiest way to get an empty /tmp directory is to tell `buildEnv` that it should "link" a /tmp dir. OK then.