### PR TITLE
nixos: Add config for defining docker sidecars

### DIFF
--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -259,7 +259,7 @@ in {
             in {
               imageFile = flake.packages.${pkgs.stdenv.targetPlatform.system}.tsnsrvOciImage;
               image = "tsnsrv:latest";
-              dependsOn = sidecar.forContainer;
+              dependsOn = [sidecar.forContainer];
               volumes = [
                 # The service's state dir; we have to infer /var/lib
                 # because the backends don't support using the

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -304,11 +304,13 @@ in {
           // (
             # systemd unit of the container we're sidecar-ing to:
             # Ensure that the sidecar is up when the "main" container is up.
-            lib.foldAttrs (lib.mapAttrsToList (name: sidecar: let
+            lib.foldAttrs (item: acc: {unitConfig.Upholds = acc.unitConfig.Upholds ++ [item];})
+            {unitConfig.Upholds = [];}
+            (lib.mapAttrsToList (name: sidecar: let
                 fromServiceName = "${config.virtualisation.oci-containers.backend}-${sidecar.forContainer}";
                 toServiceName = "${config.virtualisation.oci-containers.backend}-${name}";
               in {
-                "${fromServiceName}".unitConfig.Upholds = [toServiceName];
+                "${fromServiceName}" = toServiceName;
               })
               config.virtualisation.oci-sidecars.tsnsrv.containers)
           );

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -251,6 +251,8 @@ in {
       })
 
       (lib.mkIf config.virtualisation.oci-sidecars.tsnsrv.enable {
+        users.users.tsnsrv-sidecar.isSystemUser = true;
+
         virtualisation.oci-containers.containers =
           lib.mapAttrs' (name: sidecar: {
             inherit name;
@@ -260,6 +262,7 @@ in {
               imageFile = flake.packages.${pkgs.stdenv.targetPlatform.system}.tsnsrvOciImage;
               image = "tsnsrv:latest";
               dependsOn = [sidecar.forContainer];
+              user = config.users.users.tsnsrv-sidecar.name;
               volumes = [
                 # The service's state dir; we have to infer /var/lib
                 # because the backends don't support using the
@@ -295,7 +298,6 @@ in {
                   {
                     StateDirectory = serviceName;
                     StateDirectoryMode = "0700";
-                    DynamicUser = true;
                     SupplementaryGroups = [config.users.groups.tsnsrv.name] ++ service.supplementalGroups;
                   }
                   // lockedDownserviceConfig;

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -276,9 +276,19 @@ in {
                 # The tsnet auth key.
                 "${config.virtualisation.oci-sidecars.tsnsrv.authKeyPath}:${config.virtualisation.oci-sidecars.tsnsrv.authKeyPath}"
               ];
-              extraOptions = [
-                "--network=container:${sidecar.forContainer}"
-              ];
+              extraOptions =
+                [
+                  "--network=container:${sidecar.forContainer}"
+                ]
+                ++ (
+                  if (config.virtualisation.oci-containers.backend == "podman")
+                  then [
+                    "--passwd"
+                    "--hostuser=${config.users.users.tsnsrv-sidecar.name}"
+                    "--group-add=keep-groups"
+                  ]
+                  else []
+                );
               cmd =
                 ["-stateDir=/state"]
                 ++ (serviceArgs {

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -3,113 +3,142 @@
   config,
   lib,
   ...
-}: {
-  options = with lib; let
-    serviceSubmodule = {
-      options = {
-        authKeyPath = lib.mkOption {
-          description = "Path to a file containing a tailscale auth key. Make this a secret";
-          type = types.path;
-          default = config.services.tsnsrv.defaults.authKeyPath;
-        };
+}: let
+  serviceSubmodule = with lib; {
+    options = {
+      authKeyPath = mkOption {
+        description = "Path to a file containing a tailscale auth key. Make this a secret";
+        type = types.path;
+        default = config.services.tsnsrv.defaults.authKeyPath;
+      };
 
-        ephemeral = mkOption {
-          description = "Delete the tailnet participant shortly after it goes offline";
-          type = types.bool;
-          default = false;
-        };
+      ephemeral = mkOption {
+        description = "Delete the tailnet participant shortly after it goes offline";
+        type = types.bool;
+        default = false;
+      };
 
-        funnel = mkOption {
-          description = "Serve HTTP as a funnel, meaning that it is available on the public internet.";
-          type = types.bool;
-          default = false;
-        };
+      funnel = mkOption {
+        description = "Serve HTTP as a funnel, meaning that it is available on the public internet.";
+        type = types.bool;
+        default = false;
+      };
 
-        insecureHTTPS = mkOption {
-          description = "Disable TLS certificate validation for requests from upstream. Insecure.";
-          type = types.bool;
-          default = false;
-        };
+      insecureHTTPS = mkOption {
+        description = "Disable TLS certificate validation for requests from upstream. Insecure.";
+        type = types.bool;
+        default = false;
+      };
 
-        listenAddr = mkOption {
-          description = "Address to listen on";
-          type = types.str;
-          default = ":443";
-        };
+      listenAddr = mkOption {
+        description = "Address to listen on";
+        type = types.str;
+        default = ":443";
+      };
 
-        package = mkOption {
-          description = "Package to use for this tsnsrv service.";
-          default = config.services.tsnsrv.defaults.package;
-          type = types.package;
-        };
+      package = mkOption {
+        description = "Package to use for this tsnsrv service.";
+        default = config.services.tsnsrv.defaults.package;
+        type = types.package;
+      };
 
-        plaintext = mkOption {
-          description = "Whether to serve non-TLS-encrypted plaintext HTTP";
-          type = types.bool;
-          default = false;
-        };
+      plaintext = mkOption {
+        description = "Whether to serve non-TLS-encrypted plaintext HTTP";
+        type = types.bool;
+        default = false;
+      };
 
-        upstreamUnixAddr = mkOption {
-          description = "Connect only to the given UNIX Domain Socket";
-          type = types.nullOr types.path;
-          default = null;
-        };
+      upstreamUnixAddr = mkOption {
+        description = "Connect only to the given UNIX Domain Socket";
+        type = types.nullOr types.path;
+        default = null;
+      };
 
-        prefixes = mkOption {
-          description = "URL path prefixes to allow in forwarding. Acts as an allowlist but if unset, all prefixes are allowed.";
-          type = types.listOf types.str;
-          default = [];
-        };
+      prefixes = mkOption {
+        description = "URL path prefixes to allow in forwarding. Acts as an allowlist but if unset, all prefixes are allowed.";
+        type = types.listOf types.str;
+        default = [];
+      };
 
-        stripPrefix = mkOption {
-          description = "Strip matched prefix from request to upstream. Probably should be true when allowlisting multiple prefixes.";
-          type = types.bool;
-          default = true;
-        };
+      stripPrefix = mkOption {
+        description = "Strip matched prefix from request to upstream. Probably should be true when allowlisting multiple prefixes.";
+        type = types.bool;
+        default = true;
+      };
 
-        whoisTimeout = mkOption {
-          description = "Maximum amount of time that a requestor lookup may take.";
-          type = types.nullOr types.str;
-          default = null;
-        };
+      whoisTimeout = mkOption {
+        description = "Maximum amount of time that a requestor lookup may take.";
+        type = types.nullOr types.str;
+        default = null;
+      };
 
-        suppressWhois = mkOption {
-          description = "Disable passing requestor information to upstream service";
-          type = types.bool;
-          default = false;
-        };
+      suppressWhois = mkOption {
+        description = "Disable passing requestor information to upstream service";
+        type = types.bool;
+        default = false;
+      };
 
-        upstreamHeaders = mkOption {
-          description = "Headers to set on requests to upstream.";
-          type = types.attrsOf types.str;
-          default = {};
-        };
+      upstreamHeaders = mkOption {
+        description = "Headers to set on requests to upstream.";
+        type = types.attrsOf types.str;
+        default = {};
+      };
 
-        suppressTailnetDialer = mkOption {
-          description = "Disable using the tsnet-provided dialer, which can sometimes cause issues hitting addresses outside the tailnet";
-          type = types.bool;
-          default = false;
-        };
+      suppressTailnetDialer = mkOption {
+        description = "Disable using the tsnet-provided dialer, which can sometimes cause issues hitting addresses outside the tailnet";
+        type = types.bool;
+        default = false;
+      };
 
-        readHeaderTimeout = mkOption {
-          description = "";
-          type = types.nullOr types.str;
-          default = null;
-        };
+      readHeaderTimeout = mkOption {
+        description = "";
+        type = types.nullOr types.str;
+        default = null;
+      };
 
-        toURL = mkOption {
-          description = "URL to forward HTTP requests to";
-          type = types.str;
-        };
+      toURL = mkOption {
+        description = "URL to forward HTTP requests to";
+        type = types.str;
+      };
 
-        supplementalGroups = mkOption {
-          description = "List of groups to run the service under (in addition to the 'tsnsrv' group)";
-          type = types.listOf types.str;
-          default = [];
-        };
+      supplementalGroups = mkOption {
+        description = "List of groups to run the service under (in addition to the 'tsnsrv' group)";
+        type = types.listOf types.str;
+        default = [];
       };
     };
-  in {
+  };
+
+  serviceArgs = {
+    name,
+    service,
+  }: let
+    readHeaderTimeout =
+      if service.readHeaderTimeout == null
+      then
+        if service.funnel
+        then "1s"
+        else "0s"
+      else service.readHeaderTimeout;
+  in ([
+      "-name=${name}"
+      "-ephemeral=${lib.boolToString service.ephemeral}"
+      "-funnel=${lib.boolToString service.funnel}"
+      "-plaintext=${lib.boolToString service.plaintext}"
+      "-listenAddr=${service.listenAddr}"
+      "-stripPrefix=${lib.boolToString service.stripPrefix}"
+      "-authkeyPath=${service.authKeyPath}"
+      "-insecureHTTPS=${lib.boolToString service.insecureHTTPS}"
+      "-suppressTailnetDialer=${lib.boolToString service.suppressTailnetDialer}"
+      "-readHeaderTimeout=${readHeaderTimeout}"
+    ]
+    ++ (lib.optionals (service.whoisTimeout != null) ["-whoisTimeout" service.whoisTimeout])
+    ++ (lib.optionals (service.upstreamUnixAddr != null) ["-upstreamUnixAddr" service.upstreamUnixAddr])
+    ++ (map (p: "-prefix=${p}") service.prefixes)
+    ++ (map (h: "-upstreamHeader=${h}") (lib.mapAttrsToList (name: service: "${name}: ${service}") service.upstreamHeaders))
+    ++ [service.toURL]);
+in {
+  options = with lib; {
     services.tsnsrv.enable = mkOption {
       description = "Enable tsnsrv";
       type = types.bool;
@@ -141,44 +170,18 @@
     users.groups.tsnsrv = {};
     systemd.services =
       lib.mapAttrs' (
-        name: value:
+        name: service:
           lib.nameValuePair
           "tsnsrv-${name}"
           {
             wantedBy = ["multi-user.target"];
             after = ["network-online.target"];
-            script = let
-              readHeaderTimeout =
-                if value.readHeaderTimeout == null
-                then
-                  if value.funnel
-                  then "1s"
-                  else "0s"
-                else value.readHeaderTimeout;
-              args =
-                [
-                  "-name=${name}"
-                  "-ephemeral=${lib.boolToString value.ephemeral}"
-                  "-funnel=${lib.boolToString value.funnel}"
-                  "-plaintext=${lib.boolToString value.plaintext}"
-                  "-listenAddr=${value.listenAddr}"
-                  "-stripPrefix=${lib.boolToString value.stripPrefix}"
-                  "-authkeyPath=${value.authKeyPath}"
-                  "-insecureHTTPS=${lib.boolToString value.insecureHTTPS}"
-                  "-suppressTailnetDialer=${lib.boolToString value.suppressTailnetDialer}"
-                  "-readHeaderTimeout=${readHeaderTimeout}"
-                ]
-                ++ (lib.optionals (value.whoisTimeout != null) ["-whoisTimeout" value.whoisTimeout])
-                ++ (lib.optionals (value.upstreamUnixAddr != null) ["-upstreamUnixAddr" value.upstreamUnixAddr])
-                ++ (map (p: "-prefix=${p}") value.prefixes)
-                ++ (map (h: "-upstreamHeader=${h}") (lib.mapAttrsToList (name: value: "${name}: ${value}") value.upstreamHeaders))
-                ++ [value.toURL];
-            in ''
-              exec ${value.package}/bin/tsnsrv -stateDir=$STATE_DIRECTORY/tsnet-tsnsrv ${lib.escapeShellArgs args}
+            script = ''
+              exec ${service.package}/bin/tsnsrv -stateDir=$STATE_DIRECTORY/tsnet-tsnsrv ${lib.escapeShellArgs (serviceArgs {inherit name service;})}
             '';
             serviceConfig = {
               DynamicUser = true;
-              SupplementaryGroups = [config.users.groups.tsnsrv.name] ++ value.supplementalGroups;
+              SupplementaryGroups = [config.users.groups.tsnsrv.name] ++ service.supplementalGroups;
               StateDirectory = "tsnsrv-${name}";
               StateDirectoryMode = "0700";
 

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -4,7 +4,112 @@
   lib,
   ...
 }: {
-  options = with lib; {
+  options = with lib; let
+    serviceSubmodule = {
+      options = {
+        authKeyPath = lib.mkOption {
+          description = "Path to a file containing a tailscale auth key. Make this a secret";
+          type = types.path;
+          default = config.services.tsnsrv.defaults.authKeyPath;
+        };
+
+        ephemeral = mkOption {
+          description = "Delete the tailnet participant shortly after it goes offline";
+          type = types.bool;
+          default = false;
+        };
+
+        funnel = mkOption {
+          description = "Serve HTTP as a funnel, meaning that it is available on the public internet.";
+          type = types.bool;
+          default = false;
+        };
+
+        insecureHTTPS = mkOption {
+          description = "Disable TLS certificate validation for requests from upstream. Insecure.";
+          type = types.bool;
+          default = false;
+        };
+
+        listenAddr = mkOption {
+          description = "Address to listen on";
+          type = types.str;
+          default = ":443";
+        };
+
+        package = mkOption {
+          description = "Package to use for this tsnsrv service.";
+          default = config.services.tsnsrv.defaults.package;
+          type = types.package;
+        };
+
+        plaintext = mkOption {
+          description = "Whether to serve non-TLS-encrypted plaintext HTTP";
+          type = types.bool;
+          default = false;
+        };
+
+        upstreamUnixAddr = mkOption {
+          description = "Connect only to the given UNIX Domain Socket";
+          type = types.nullOr types.path;
+          default = null;
+        };
+
+        prefixes = mkOption {
+          description = "URL path prefixes to allow in forwarding. Acts as an allowlist but if unset, all prefixes are allowed.";
+          type = types.listOf types.str;
+          default = [];
+        };
+
+        stripPrefix = mkOption {
+          description = "Strip matched prefix from request to upstream. Probably should be true when allowlisting multiple prefixes.";
+          type = types.bool;
+          default = true;
+        };
+
+        whoisTimeout = mkOption {
+          description = "Maximum amount of time that a requestor lookup may take.";
+          type = types.nullOr types.str;
+          default = null;
+        };
+
+        suppressWhois = mkOption {
+          description = "Disable passing requestor information to upstream service";
+          type = types.bool;
+          default = false;
+        };
+
+        upstreamHeaders = mkOption {
+          description = "Headers to set on requests to upstream.";
+          type = types.attrsOf types.str;
+          default = {};
+        };
+
+        suppressTailnetDialer = mkOption {
+          description = "Disable using the tsnet-provided dialer, which can sometimes cause issues hitting addresses outside the tailnet";
+          type = types.bool;
+          default = false;
+        };
+
+        readHeaderTimeout = mkOption {
+          description = "";
+          type = types.nullOr types.str;
+          default = null;
+        };
+
+        toURL = mkOption {
+          description = "URL to forward HTTP requests to";
+          type = types.str;
+        };
+
+        supplementalGroups = mkOption {
+          description = "List of groups to run the service under (in addition to the 'tsnsrv' group)";
+          type = types.listOf types.str;
+          default = [];
+        };
+      };
+    };
+  in {
     services.tsnsrv.enable = mkOption {
       description = "Enable tsnsrv";
       type = types.bool;
@@ -27,110 +132,7 @@
     services.tsnsrv.services = mkOption {
       description = "tsnsrv services";
       default = {};
-      type = types.attrsOf (types.submodule {
-        options = {
-          authKeyPath = lib.mkOption {
-            description = "Path to a file containing a tailscale auth key. Make this a secret";
-            type = types.path;
-            default = config.services.tsnsrv.defaults.authKeyPath;
-          };
-
-          ephemeral = mkOption {
-            description = "Delete the tailnet participant shortly after it goes offline";
-            type = types.bool;
-            default = false;
-          };
-
-          funnel = mkOption {
-            description = "Serve HTTP as a funnel, meaning that it is available on the public internet.";
-            type = types.bool;
-            default = false;
-          };
-
-          insecureHTTPS = mkOption {
-            description = "Disable TLS certificate validation for requests from upstream. Insecure.";
-            type = types.bool;
-            default = false;
-          };
-
-          listenAddr = mkOption {
-            description = "Address to listen on";
-            type = types.str;
-            default = ":443";
-          };
-
-          package = mkOption {
-            description = "Package to use for this tsnsrv service.";
-            default = config.services.tsnsrv.defaults.package;
-            type = types.package;
-          };
-
-          plaintext = mkOption {
-            description = "Whether to serve non-TLS-encrypted plaintext HTTP";
-            type = types.bool;
-            default = false;
-          };
-
-          upstreamUnixAddr = mkOption {
-            description = "Connect only to the given UNIX Domain Socket";
-            type = types.nullOr types.path;
-            default = null;
-          };
-
-          prefixes = mkOption {
-            description = "URL path prefixes to allow in forwarding. Acts as an allowlist but if unset, all prefixes are allowed.";
-            type = types.listOf types.str;
-            default = [];
-          };
-
-          stripPrefix = mkOption {
-            description = "Strip matched prefix from request to upstream. Probably should be true when allowlisting multiple prefixes.";
-            type = types.bool;
-            default = true;
-          };
-
-          whoisTimeout = mkOption {
-            description = "Maximum amount of time that a requestor lookup may take.";
-            type = types.nullOr types.str;
-            default = null;
-          };
-
-          suppressWhois = mkOption {
-            description = "Disable passing requestor information to upstream service";
-            type = types.bool;
-            default = false;
-          };
-
-          upstreamHeaders = mkOption {
-            description = "Headers to set on requests to upstream.";
-            type = types.attrsOf types.str;
-            default = {};
-          };
-
-          suppressTailnetDialer = mkOption {
-            description = "Disable using the tsnet-provided dialer, which can sometimes cause issues hitting addresses outside the tailnet";
-            type = types.bool;
-            default = false;
-          };
-
-          readHeaderTimeout = mkOption {
-            description = "";
-            type = types.nullOr types.str;
-            default = null;
-          };
-
-          toURL = mkOption {
-            description = "URL to forward HTTP requests to";
-            type = types.str;
-          };
-
-          supplementalGroups = mkOption {
-            description = "List of groups to run the service under (in addition to the 'tsnsrv' group)";
-            type = types.listOf types.str;
-            default = [];
-          };
-        };
-      });
+      type = types.attrsOf (types.submodule serviceSubmodule);
       example = false;
     };
   };

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -224,8 +224,9 @@ in {
     };
   in
     lib.mkMerge [
+      (lib.mkIf (config.services.tsnsrv.enable or config.virtualisation.oci-sidecars.tsnsrv.enable)
+        {users.groups.tsnsrv = {};})
       (lib.mkIf config.services.tsnsrv.enable {
-        users.groups.tsnsrv = {};
         systemd.services =
           lib.mapAttrs' (
             name: service:
@@ -251,7 +252,10 @@ in {
       })
 
       (lib.mkIf config.virtualisation.oci-sidecars.tsnsrv.enable {
-        users.users.tsnsrv-sidecar.isSystemUser = true;
+        users.users.tsnsrv-sidecar = {
+          isSystemUser = true;
+          group = config.users.groups.tsnsrv.name;
+        };
 
         virtualisation.oci-containers.containers =
           lib.mapAttrs' (name: sidecar: {

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -280,7 +280,7 @@ in {
                 });
             };
           })
-          config.virtualisation.oci-sidecars.containers;
+          config.virtualisation.oci-sidecars.tsnsrv.containers;
 
         systemd.services =
           (
@@ -299,7 +299,7 @@ in {
                 }
                 // lockedDownserviceConfig;
             })
-            config.virtualisation.oci-sidecars.containers
+            config.virtualisation.oci-sidecars.tsnsrv.containers
           )
           // (
             # systemd unit of the container we're sidecar-ing to:
@@ -310,7 +310,7 @@ in {
               in {
                 "${fromServiceName}".unitConfig.Upholds = [toServiceName];
               })
-              config.virtualisation.oci-sidecars.containers)
+              config.virtualisation.oci-sidecars.tsnsrv.containers)
           );
       })
     ];

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -178,6 +178,12 @@ in {
         description = "Attrset mapping sidecar container names to their respective tsnsrv service definition. Each sidecar container will be attached to the container it belongs to, sharing its network.";
         type = types.attrsOf (types.submodule {
           options = {
+            name = mkOption {
+              description = "Name to use for the tsnet service. This defaults to the container name.";
+              type = types.nullOr types.str;
+              default = null;
+            };
+
             forContainer = mkOption {
               description = "The container to which to attach the sidecar.";
               type = types.str; # TODO: see if we can constrain this to all the oci containers in the system definition, with types.oneOf or an appropriate check.
@@ -277,7 +283,10 @@ in {
               cmd =
                 ["-stateDir=/state"]
                 ++ (serviceArgs {
-                  inherit name;
+                  name =
+                    if sidecar.name == null
+                    then name
+                    else sidecar.name;
                   inherit (sidecar) service;
                 });
             };

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -290,14 +290,16 @@ in {
               service = sidecar.service;
             in {
               name = serviceName;
-              value =
-                {
-                  StateDirectory = serviceName;
-                  StateDirectoryMode = "0700";
-                  DynamicUser = true;
-                  SupplementaryGroups = [config.users.groups.tsnsrv.name] ++ service.supplementalGroups;
-                }
-                // lockedDownserviceConfig;
+              value = {
+                serviceConfig =
+                  {
+                    StateDirectory = serviceName;
+                    StateDirectoryMode = "0700";
+                    DynamicUser = true;
+                    SupplementaryGroups = [config.users.groups.tsnsrv.name] ++ service.supplementalGroups;
+                  }
+                  // lockedDownserviceConfig;
+              };
             })
             config.virtualisation.oci-sidecars.tsnsrv.containers
           )

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -266,7 +266,7 @@ in {
               imageFile = flake.packages.${pkgs.stdenv.targetPlatform.system}.tsnsrvOciImage;
               image = "tsnsrv:latest";
               dependsOn = [sidecar.forContainer];
-              user = config.users.users.tsnsrv-sidecar.name;
+              user = "${config.users.users.tsnsrv-sidecar.name}:${config.users.groups.tsnsrv.name}";
               volumes = [
                 # The service's state dir; we have to infer /var/lib
                 # because the backends don't support using the

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -298,13 +298,11 @@ in {
             in {
               name = serviceName;
               value = {
-                serviceConfig =
-                  {
-                    StateDirectory = serviceName;
-                    StateDirectoryMode = "0700";
-                    SupplementaryGroups = [config.users.groups.tsnsrv.name] ++ service.supplementalGroups;
-                  }
-                  // lockedDownserviceConfig;
+                serviceConfig = {
+                  StateDirectory = serviceName;
+                  StateDirectoryMode = "0700";
+                  SupplementaryGroups = [config.users.groups.tsnsrv.name] ++ service.supplementalGroups;
+                };
               };
             })
             config.virtualisation.oci-sidecars.tsnsrv.containers

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -251,7 +251,7 @@ in {
       })
 
       (lib.mkIf config.virtualisation.oci-sidecars.tsnsrv.enable {
-        virtualisation.oci-containers =
+        virtualisation.oci-containers.containers =
           lib.mapAttrs' (name: sidecar: {
             inherit name;
             value = let


### PR DESCRIPTION
This fixes #28, when done.

There is one really unfortunate bit about this: You can't run this rootless or as a non-root user, really (due to several problems on nixos's oci-containers side: https://github.com/NixOS/nixpkgs/issues/138423, https://github.com/NixOS/nixpkgs/issues/207050, https://github.com/containers/podman/issues/18903 and a fun bug in podman too: https://github.com/containers/podman/issues/19800).

...but otherwise, this works really well for me, at least under podman.