### PR TITLE
fix: remove new line characters from authfile

### DIFF
--- a/main.go
+++ b/main.go
@@ -171,7 +171,7 @@ func authkeyFromFile(path string) (string, error) {
 	}
 	defer f.Close()
 	key, err := io.ReadAll(f)
-	return string(key), err
+	return strings.TrimSpace(string(key)), err
 }
 
 func (s *validTailnetSrv) run(ctx context.Context) error {


### PR DESCRIPTION
Hi, thanks for the nice project.
I noticed when I set up the nixos module, I prepared the authfile with commands, `echo tskey-auth-xxx > authkey` and it fails to start with the following error.
```
2023/09/20 18:46:39 could not connect to tailnet: tsnet.Up: backend: invalid key: unable to validate API key
```
After some debugging, I found that it seems to be caused by an inserted newline character at the end of the authkey.
This is a small PR to remove the newline character.
Please let me know if the authfile is misformatted.