### PR TITLE
Dedup docker builds

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,8 +11,6 @@ on:
   push:
     # Publish semver tags as releases.
     tags: ["v*.*.*"]
-    # Publish every push to main:
-    branches: ["main"]
   workflow_dispatch:
   workflow_call:
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -46,7 +46,7 @@ jobs:
     steps:
       - name: Determine whether to push
         id: docker_pushable
-        run: echo should=${{ toJSON(github.event_name != 'pull_request') }} >>$GITHUB_OUTPUT
+        run: echo should=${{ toJSON(github.event_name != 'pull_request' && github.event_name != 'merge_group') }} >>$GITHUB_OUTPUT
 
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
This should tighten some screws that #50 overly loosened: Don't build on merge group builds, and only build one push to main at a time.