### PR TITLE
Correct cross-compiling of docker image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,19 +23,6 @@ env:
 jobs:
   docker_build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64
-        isPR:
-          - ${{ github.event_name == 'pull_request' }}
-
-        # Run only the amd64 build in pull reqs:
-        exclude:
-          - { isPR: true }
-        include:
-          - { platform: "linux/amd64" }
     permissions:
       contents: read
       packages: write
@@ -47,6 +34,10 @@ jobs:
       - name: Determine whether to push
         id: docker_pushable
         run: echo should=${{ toJSON(github.event_name != 'pull_request' && github.event_name != 'merge_group') }} >>$GITHUB_OUTPUT
+      - name: Determine build platforms
+        id: platforms
+        run: |
+          echo platforms=${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }} >>$GITHUB_OUTPUT
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -74,12 +65,12 @@ jobs:
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
-      - name: Build and push Docker image for ${{matrix.platform}}
+      - name: Build and push Docker image for ${{steps.platforms.outputs.platforms}}
         id: build-and-push
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: ${{ matrix.platform }}
+          platforms: ${{ steps.platforms.outputs.platforms }}
           push: ${{ steps.docker_pushable.outputs.should }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM golang:1.21 as builder
+FROM --platform=$TARGETPLATFORM golang:1.21 as builder
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
 
 WORKDIR /work
 ENV CGO_ENABLED=0
@@ -14,7 +16,7 @@ COPY . .
 
 RUN go build -ldflags="-s -w" -v
 
-FROM scratch
+FROM --platform=$TARGETPLATFORM scratch
 COPY --from=builder /work/tsnsrv /usr/bin/tsnsrv
 
 CMD ["/usr/bin/tsnsrv"]


### PR DESCRIPTION
* Set the $TARGETPLATFORM platform when requesting image bases
* Don't use the build matrix: apparently there's a race where whatever platform gets pushed first "locks" the available arches on that tag. Instead, build both on the same builder (ugh), and then push them both.

This fixes #48 