### PR TITLE
Drop semanticrelease from the build steps in docker-publish.yml

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -41,9 +41,6 @@ jobs:
         run: |
           nix build .#tsnsrvOciImage-cross-aarch64-linux .#tsnsrvOciImage
 
-      - uses: cihelper/action-semanticrelease-goreleaser@v1
-        id: semanticrelease
-
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}


### PR DESCRIPTION
It's not used, but tries to push to the main branch?! Let's drop it.