### PR TITLE
Add order for nixos module systemd service

### DIFF
--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -248,6 +248,7 @@ in {
               {
                 wantedBy = ["multi-user.target"];
                 after = ["network-online.target"];
+                wants = ["network-online.target"];
                 script = ''
                   exec ${service.package}/bin/tsnsrv -stateDir=$STATE_DIRECTORY/tsnet-tsnsrv ${lib.escapeShellArgs (serviceArgs {inherit name service;})}
                 '';


### PR DESCRIPTION
When trying to run the nixos module service I got the following error:
```
...

error:
       Failed assertions:
       - tsnsrv-bla.service is ordered after 'network-online.target' but doesn't depend on it
```

And with a bit of searching I found [this nixpkgs PR](https://github.com/NixOS/nixpkgs/pull/282795) where they try to fix similair issues.