### PR TITLE
Replace deprecated Nix vendorSha256 call with vendorHash

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -72,7 +72,7 @@
                 rev = "v${version}";
                 sha256 = "sha256-HjN8VzysxQvx5spXgbgbItH3y1bLbfHO+udNQMuyhAk=";
               };
-              vendorSha256 = "sha256-LIvaxSo+4LuHUk8DIZ27IaRQwaDnjW6Jwm5AEc/V95A=";
+              vendorHash = "sha256-LIvaxSo+4LuHUk8DIZ27IaRQwaDnjW6Jwm5AEc/V95A=";
 
               subPackages = ["cmd/nardump"];
             };


### PR DESCRIPTION
When including the flake into my nixos system and doing a rebuild I get the following error:
```
trace: warning: 'vendorSha256' is deprecated. Use 'vendorHash' instead
```

The `vendorHash` function is a drop in replacement, so with this PR the warning will be gone.

(The deprecation of `vendorSha256` can be verified by checking the [nixos 23.11 release notes](https://nixos.org/manual/nixos/stable/release-notes#sec-release-23.11) that say "The argument vendorSha256 of buildGoModule is deprecated. Use vendorHash instead. Refer to [PR #259999](https://github.com/NixOS/nixpkgs/pull/259999) for more details.")