### PR TITLE
Fix missused or

### DIFF
--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -237,7 +237,7 @@ in {
     };
   in
     lib.mkMerge [
-      (lib.mkIf (config.services.tsnsrv.enable or config.virtualisation.oci-sidecars.tsnsrv.enable)
+      (lib.mkIf (config.services.tsnsrv.enable || config.virtualisation.oci-sidecars.tsnsrv.enable)
         {users.groups.tsnsrv = {};})
       (lib.mkIf config.services.tsnsrv.enable {
         systemd.services =


### PR DESCRIPTION
or is only used if the left part of it does not exist. In that case we want to use the logical or ||