### PR TITLE
Attempt to fix DERP connectivity in the e2e test

### DIFF
--- a/nixos/tests/flake-part.nix
+++ b/nixos/tests/flake-part.nix
@@ -73,6 +73,7 @@
                 };
               };
               services.tailscale.enable = true;
+              systemd.services.tailscaled.serviceConfig.Environment = ["TS_NO_LOGS_NO_SUPPORT=true"];
               networking.firewall = {
                 allowedTCPPorts = [80 443];
                 allowedUDPPorts = [stunPort];


### PR DESCRIPTION
This prevents it from attempting to connect to log.tailscale.com, which is impossible in the sandbox. Speeds up startup by a few milliseconds, but mostly reduces log spam.