### PR TITLE
Add an option -listenLocally

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,3 +16,4 @@ linters:
     - unused
   disable:
     - depguard
+    - perfsprint

--- a/cli.go
+++ b/cli.go
@@ -244,7 +244,7 @@ func (s *ValidTailnetSrv) Run(ctx context.Context) error {
 	}
 	if s.UpstreamTCPAddr != "" {
 		dialOrig := dial
-		dial = func(ctx context.Context, network, address string) (net.Conn, error) {
+		dial = func(ctx context.Context, _, _ string) (net.Conn, error) {
 			conn, err := dialOrig(ctx, "tcp", s.UpstreamTCPAddr)
 			if err != nil {
 				return nil, fmt.Errorf("connecting to tcp %v: %w", s.UpstreamTCPAddr, err)
@@ -252,7 +252,7 @@ func (s *ValidTailnetSrv) Run(ctx context.Context) error {
 			return conn, nil
 		}
 	} else if s.UpstreamUnixAddr != "" {
-		dial = func(ctx context.Context, network, address string) (net.Conn, error) {
+		dial = func(ctx context.Context, _, _ string) (net.Conn, error) {
 			d := net.Dialer{}
 			conn, err := d.DialContext(ctx, "unix", s.UpstreamUnixAddr)
 			if err != nil {

--- a/cli_test.go
+++ b/cli_test.go
@@ -24,11 +24,14 @@ func TestFromArgs(t *testing.T) {
 		{"funnel", []string{"-name", "foo", "-funnel=true", "http://example.com"}, true},
 		{"funnelOnly", []string{"-name", "foo", "-funnel=true", "-funnelOnly", "http://example.com"}, true},
 		{"ephemeral", []string{"-name", "foo", "-ephemeral=true", "http://example.com"}, true},
+		{"local", []string{"-name", "foo", "-listenLocally=true", "-plaintext=true", "http://example.com"}, true},
 
 		// Expected to fail:
 		{"no args", []string{}, false},
 		{"both addrs", []string{"-name", "foo", "-upstreamTCPAddr=127.0.0.1:80", "-upstreamUnixAddr=/tmp/foo.sock", "http://example.com"}, false},
 		{"plaintext on funnel", []string{"-name", "foo", "-plaintext=true", "-funnel", "http://example.com"}, false},
+		{"local on funnel", []string{"-name", "foo", "-listenLocally=true", "-funnel", "http://example.com"}, false},
+		{"local sans plaintext", []string{"-name", "foo", "-listenLocally=true", "http://example.com"}, false},
 		{"invalid funnelOnly", []string{"-name", "foo", "-funnelOnly", "http://example.com"}, false},
 		{"invalid destination URL", []string{"-name", "foo", "::--example.com"}, false},
 	} {

--- a/proxy.go
+++ b/proxy.go
@@ -74,8 +74,10 @@ func (s *ValidTailnetSrv) modifyResponse(res *http.Response) error {
 	return nil
 }
 
-func (s *ValidTailnetSrv) errorHandler(rw http.ResponseWriter, _ *http.Request, err error) {
+func (s *ValidTailnetSrv) errorHandler(rw http.ResponseWriter, req *http.Request, err error) {
 	slog.Warn("proxy error",
+		"request_uri", req.URL.String(),
+		"request_method", req.Method,
 		"error", err,
 	)
 	proxyErrors.Inc()


### PR DESCRIPTION
This allows tsnsrv to proxy requests _into_ the tailnet from an external address - almost like tailscale funnel does, except only on the network address you decide where it listens on.