### PR TITLE
oci containers: depend on the correct service name

### DIFF
--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -438,7 +438,7 @@ in {
           // (
             # systemd unit of the container we're sidecar-ing to:
             # Ensure that the sidecar is up when the "main" container is up.
-            lib.foldAttrs (item: acc: {unitConfig.Upholds = acc.unitConfig.Upholds ++ [item];})
+            lib.foldAttrs (item: acc: {unitConfig.Upholds = acc.unitConfig.Upholds ++ ["${item}.service"];})
             {unitConfig.Upholds = [];}
             (lib.mapAttrsToList (name: sidecar: let
                 fromServiceName = "${config.virtualisation.oci-containers.backend}-${sidecar.forContainer}";


### PR DESCRIPTION
I'd forgotten they have to be identified as "[...].service". Whoops.