### PR TITLE
Set stopIfChanged=false on the systemd service

### DIFF
--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -392,6 +392,7 @@ in {
                     "-authkeyPath=$CREDENTIALS_DIRECTORY/authKey" \
                     ${lib.escapeShellArgs (serviceArgs {inherit name service;})}
                 '';
+                stopIfChanged = false;
                 serviceConfig =
                   {
                     DynamicUser = true;


### PR DESCRIPTION
Using stop/start on system changes means that the service gets interrupted for seconds (or minutes!) at a time, which isn't really necessary in tsnsrv's case. Instead, this tells systemd to just restart the service (killing the existing process and re-executing the updated command line), which is far faster.