### PR TITLE
Bump flocken to 2.5

### DIFF
--- a/dev/flake-part.nix
+++ b/dev/flake-part.nix
@@ -48,13 +48,9 @@
             else ref;
         in {
           autoTags = {
-            branch = !isPR;
+            branch = true;
             version = true;
           };
-          tags =
-            if isPR
-            then [branch]
-            else [];
           inherit branch;
 
           github = {

--- a/dev/flake.lock
+++ b/dev/flake.lock
@@ -77,11 +77,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1737364810,
-        "narHash": "sha256-5RUkG7Z/2u2W09T6ZIdH7k3L27sdb5zWdSexLW4xFqE=",
+        "lastModified": 1737581094,
+        "narHash": "sha256-MSjyNy4zENfngnSdXQ6ef/wwACB0jfDyhy0qkI67F9A=",
         "owner": "mirkolenz",
         "repo": "flocken",
-        "rev": "b79e6c3c40f6f6b30ff9e772c2c36ee517b1dbe3",
+        "rev": "97921a2650cb3de20c2a5ee591b00a6d5099fc40",
         "type": "github"
       },
       "original": {

--- a/dev/flake.lock
+++ b/dev/flake.lock
@@ -39,11 +39,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1733312601,
-        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
+        "lastModified": 1736143030,
+        "narHash": "sha256-+hu54pAoLDEZT9pjHlqL9DNzWz0NbUn8NEAHP7PQPzU=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
+        "rev": "b905f6fc23a9051a6e1b741e1438dbfc0634c6de",
         "type": "github"
       },
       "original": {
@@ -77,11 +77,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1734815773,
-        "narHash": "sha256-+pWdOI1NvwmUtqVPat0shY70ttfEeJyWns3BAy3GX0U=",
+        "lastModified": 1737364810,
+        "narHash": "sha256-5RUkG7Z/2u2W09T6ZIdH7k3L27sdb5zWdSexLW4xFqE=",
         "owner": "mirkolenz",
         "repo": "flocken",
-        "rev": "98893927bddea7439378fd10c00f7661660fb006",
+        "rev": "b79e6c3c40f6f6b30ff9e772c2c36ee517b1dbe3",
         "type": "github"
       },
       "original": {
@@ -128,23 +128,23 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1733096140,
-        "narHash": "sha256-1qRH7uAUsyQI7R1Uwl4T+XvdNv778H0Nb5njNrqvylY=",
+        "lastModified": 1735774519,
+        "narHash": "sha256-CewEm1o2eVAnoqb6Ml+Qi9Gg/EfNAxbRx1lANGVyoLI=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5487e69da40cbd611ab2cadee0b4637225f7cfae.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5487e69da40cbd611ab2cadee0b4637225f7cfae.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz"
       }
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1734126203,
-        "narHash": "sha256-0XovF7BYP50rTD2v4r55tR5MuBLet7q4xIz6Rgh3BBU=",
+        "lastModified": 1737110817,
+        "narHash": "sha256-DSenga8XjPaUV5KUFW/i3rNkN7jm9XmguW+qQ1ZJTR4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "71a6392e367b08525ee710a93af2e80083b5b3e2",
+        "rev": "041c867bad68dfe34b78b2813028a2e2ea70a23c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This version should address https://github.com/mirkolenz/flocken/issues/84, which cleans up the docker build config a bit.