### PR TITLE
Fix token generation and usage for the SRI update workflow

### DIFF
--- a/.github/workflows/auto_update_sri_pr.yml
+++ b/.github/workflows/auto_update_sri_pr.yml
@@ -1,7 +1,7 @@
 # This action is suuuuper ripped off from tailscale's:
 # https://github.com/tailscale/tailscale/blob/main/.github/workflows/update-flake.yml
 
-name: "File PR for updated SRI hash"
+name: "Update vendor SRI hash on PR"
 on:
   push:
     branches:
@@ -28,14 +28,17 @@ jobs:
       contents: write
     steps:
       - name: Generate token
-        id: generate-token
+        id: generate_token
         uses: tibdex/github-app-token@v2
         with:
           app_id: ${{ vars.PR_FIXUP_APP_ID }}
           private_key: ${{ secrets.PR_FIXUP_APP_PRIVATE_KEY }}
+          installation_id: ${{ vars.PR_FIXUP_INSTALLATION_ID }}
+          permissions: >-
+            {"contents": "write", "pull_requests": "write"}
       - uses: actions/checkout@v4
         with:
-          token: ${{secrets.REPO_CONTENT_UPDATE_TOKEN}}
+          token: ${{steps.generate_token.outputs.token}}
           fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
       - uses: cachix/install-nix-action@v30
       - uses: DeterminateSystems/magic-nix-cache-action@v8
@@ -53,7 +56,7 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         if: github.event_name != 'workflow_dispatch' || !github.event.inputs.push_change
         with:
-          token: ${{ steps.generate-token.outputs.token }}
+          token: ${{ steps.generate_token.outputs.token }}
           author: Flakes Updater <noreply+flakes-updater@boinkor.net>
           committer: Flakes Updater <noreply+flakes-updater@boinkor.net>
           branch: auto-update-sri


### PR DESCRIPTION
This is similar to what we had to do on github.com/boinkor-net/hoopsnake: The repo update token has expired, so that workflow can no longer run.