### PR TITLE
Untangle e2e tests, get them passing more often

### DIFF
--- a/nixos/tests/e2e/oci-urlparts.nix
+++ b/nixos/tests/e2e/oci-urlparts.nix
@@ -6,7 +6,7 @@
   stunPort = 3478;
 in
   nixos-lib.runTest {
-    name = "tsnsrv-nixos";
+    name = "oci-urlparts";
     hostPkgs = pkgs;
 
     nodes.headscale = {

--- a/nixos/tests/e2e/oci.nix
+++ b/nixos/tests/e2e/oci.nix
@@ -6,7 +6,7 @@
   stunPort = 3478;
 in
   nixos-lib.runTest {
-    name = "tsnsrv-nixos";
+    name = "oci";
     hostPkgs = pkgs;
 
     nodes.headscale = {

--- a/nixos/tests/e2e/systemd-urlparts.nix
+++ b/nixos/tests/e2e/systemd-urlparts.nix
@@ -6,7 +6,7 @@
   stunPort = 3478;
 in
   nixos-lib.runTest {
-    name = "tsnsrv-nixos";
+    name = "systemd-urlparts";
     hostPkgs = pkgs;
 
     defaults.services.tsnsrv.enable = true;
@@ -82,6 +82,7 @@ in
       systemd.services.tsnsrv-basic = {
         enableStrictShellChecks = true;
         wants = ["generate-tsnsrv-authkey@basic.service"];
+        requires = ["generate-tsnsrv-authkey@basic.service"];
         after = ["generate-tsnsrv-authkey@basic.service"];
         unitConfig.Requires = ["generate-tsnsrv-authkey@basic.service"];
       };

--- a/nixos/tests/e2e/systemd.nix
+++ b/nixos/tests/e2e/systemd.nix
@@ -6,7 +6,7 @@
   stunPort = 3478;
 in
   nixos-lib.runTest {
-    name = "tsnsrv-nixos";
+    name = "systemd";
     hostPkgs = pkgs;
 
     defaults.services.tsnsrv.enable = true;
@@ -82,6 +82,7 @@ in
       systemd.services.tsnsrv-basic = {
         enableStrictShellChecks = true;
         wants = ["generate-tsnsrv-authkey@basic.service"];
+        requires = ["generate-tsnsrv-authkey@basic.service"];
         after = ["generate-tsnsrv-authkey@basic.service"];
         unitConfig.Requires = ["generate-tsnsrv-authkey@basic.service"];
       };


### PR DESCRIPTION
It looks like one of the OCI tests isn't passing consistently (more like, is failing consistently): https://github.com/boinkor-net/tsnsrv/actions/runs/13899049200/job/38962220672#step:3:6411 - looks like the headscale credentials-creating process gets killed because the tsnsrv container fails to come up, which it shouldn't at that point in time.